### PR TITLE
Expose client connection state requests

### DIFF
--- a/iotdevice/client.go
+++ b/iotdevice/client.go
@@ -151,6 +151,21 @@ func (c *Client) Connect(ctx context.Context) error {
 	return err
 }
 
+// IsConnected forwards true if transport is connected
+func (c *Client) IsConnected() (bool, error) {
+	if c.tr == nil {
+		return false, errors.New("transport is not available")
+	}
+	return c.tr.IsConnected()
+}
+
+func (c *Client) IsConnectionOpen() (bool, error) {
+	if c.tr == nil {
+		return true, errors.New("transport is not available")
+	}
+	return c.tr.IsConnectionOpen()
+}
+
 // ErrClosed the client is already closed.
 var ErrClosed = errors.New("closed")
 

--- a/iotdevice/transport/http/http.go
+++ b/iotdevice/transport/http/http.go
@@ -97,6 +97,14 @@ func (tr *Transport) Connect(ctx context.Context, creds transport.Credentials) e
 	return nil
 }
 
+func (tr *Transport) IsConnected() (bool, error) {
+	return false, ErrNotImplemented
+}
+
+func (tr *Transport) IsConnectionOpen() (bool, error) {
+	return false, ErrNotImplemented
+}
+
 // Send is not available in the HTTP transport.
 func (tr *Transport) Send(ctx context.Context, msg *common.Message) error {
 	return ErrNotImplemented

--- a/iotdevice/transport/transport.go
+++ b/iotdevice/transport/transport.go
@@ -15,6 +15,8 @@ import (
 type Transport interface {
 	SetLogger(logger logger.Logger)
 	Connect(ctx context.Context, creds Credentials) error
+	IsConnected() (bool, error)
+	IsConnectionOpen() (bool, error)
 	Send(ctx context.Context, msg *common.Message) error
 	RegisterDirectMethods(ctx context.Context, mux MethodDispatcher) error
 	SubscribeEvents(ctx context.Context, mux MessageDispatcher) error


### PR DESCRIPTION
There is a rare case, when the mqtt-client looses connection and waits for its workers to stop but never finishes, if one or more workers are stuck ([internalConnLost (paho.mqtt)](https://github.com/eclipse/paho.mqtt.golang/blob/1a63b636dbd0fbf3f4708e9b309728b9a08fd98b/client.go#L544)). In this case the client never starts the reconnection phase and even when a connection would be possible again, we will not be able to request anything and will run into context deadline. To be able to detect this situation and start countermeasures, we need to be able to get the connection state of the mqtt-client, which is already provided and just needs to be exposed.